### PR TITLE
Support inline source maps

### DIFF
--- a/spec/stacktrace-gps-spec.js
+++ b/spec/stacktrace-gps-spec.js
@@ -372,5 +372,32 @@ describe('StackTraceGPS', function () {
                expect(errback).not.toHaveBeenCalled();
            });
        });
+
+        it('supports inline source maps', function() {
+            runs(function() {
+                var sourceMin = 'var foo=function(){};function bar(){}var baz=eval("XXX");//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInRlc3QuanMiXSwibmFtZXMiOlsiZm9vIiwiYmFyIiwiYmF6IiwiZXZhbCJdLCJtYXBwaW5ncyI6IkFBQUEsR0FBSUEsS0FBTSxZQUdWLFNBQVNDLFFBRVQsR0FBSUMsS0FBTUMsS0FBTSJ9';
+                server.respondWith('GET', 'http://localhost:9999/test.min.js', [200, { 'Content-Type': 'application/x-javascript' }, sourceMin]);
+
+                var stackframe = new StackFrame(undefined, [], 'http://localhost:9999/test.min.js', 1, 47);
+                new StackTraceGPS().pinpoint(stackframe).then(callback, errback)['catch'](debugErrback);
+            });
+            waits(100);
+            runs(function() {
+                server.respond();
+            });
+            waits(100);
+            runs(function() {
+                server.respond();
+            });
+            waits(100);
+            runs(function() {
+                server.respond();
+            });
+            waits(100);
+            runs(function() {
+                expect(callback).toHaveBeenCalledWith(new StackFrame('eval', [], 'test.js', 3, 10));
+                expect(errback).not.toHaveBeenCalled();
+            });
+        });
     });
 });


### PR DESCRIPTION
Only `application/json;base64` format is supported. I'm not sure if others exist.

Relies on `atob()` in the browser, which is **not available in IE <= 9**!

I'm pretty sure the test isn't proper. But I'm on Windows and couldn't get the existing tests to properly pass and I'm not familiar with the mocking approach. But, hopefully, it's a start.

I'm also not sure if one should use `new String(buffer)` or `buffer.toString()` in Node/IO environments. Comments are welcome.

Fixes #7