### PR TITLE
Source map improvements: Resolve content from sourceContent and fix inline source map issue

### DIFF
--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -103,19 +103,19 @@
     }
 
     function _extractLocationInfoFromSourceMap(rawSourceMap, args, lineNumber, columnNumber, sourceCache) {
-        var mapConsumer = new SourceMap.SourceMapConsumer(rawSourceMap)
+        var mapConsumer = new SourceMap.SourceMapConsumer(rawSourceMap);
 
         var loc = mapConsumer.originalPositionFor({
           line: lineNumber,
           column: columnNumber
-        })
+        });
 
-        var mappedSource = mapConsumer.sourceContentFor(loc.source)
+        var mappedSource = mapConsumer.sourceContentFor(loc.source);
         if (mappedSource) {
-          sourceCache[loc.source] = mappedSource
+          sourceCache[loc.source] = mappedSource;
         }
 
-        return new StackFrame(loc.name, args, loc.source, loc.line, loc.column)
+        return new StackFrame(loc.name, args, loc.source, loc.line, loc.column);
     }
 
     /**
@@ -223,11 +223,11 @@
                 _ensureSupportedEnvironment();
                 _ensureStackFrameIsLegit(stackframe);
 
-                var sourceCache = this.sourceCache
+                var sourceCache = this.sourceCache;
                 var fileName = stackframe.fileName;
                 this._get(fileName).then(function (source) {
                     var sourceMappingURL = _findSourceMappingURL(source);
-                    var isDataUrl = sourceMappingURL.substr(0, 5) === 'data:'
+                    var isDataUrl = sourceMappingURL.substr(0, 5) === 'data:';
 
                     if (sourceMappingURL[0] !== '/' && !isDataUrl) {
                         sourceMappingURL = fileName.substring(0, fileName.lastIndexOf('/') + 1) + sourceMappingURL;

--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -216,7 +216,9 @@
                 var fileName = stackframe.fileName;
                 this._get(fileName).then(function (source) {
                     var sourceMappingURL = _findSourceMappingURL(source);
-                    if (sourceMappingURL[0] !== '/') {
+                    var isDataUrl = sourceMappingURL.substr(0, 5) === 'data:'
+
+                    if (sourceMappingURL[0] !== '/' && !isDataUrl) {
                         sourceMappingURL = fileName.substring(0, fileName.lastIndexOf('/') + 1) + sourceMappingURL;
                     }
                     this._get(sourceMappingURL).then(function (map) {


### PR DESCRIPTION
This PR fixes the issue of inline source maps (data-urls) being prepended with base url (#17), and adds the logic to extract sourceContent from source map and inject into cache, which makes source mapped assets resolvable by the ``_get`` method.

This could probably be covered by a new test.
