### PR TITLE
Allow matching of sourceMappingURL lines with whitespace before the EOF

### DIFF
--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -96,7 +96,7 @@
     }
 
     function _findSourceMappingURL(source) {
-        var m = /\/\/[#@] ?sourceMappingURL=([^\s'"]+)$/.exec(source);
+        var m = /\/\/[#@] ?sourceMappingURL=([^\s'"]+)\s*$/.exec(source);
         if (m && m[1]) {
             return m[1];
         } else {


### PR DESCRIPTION
My source map wasn't being loaded because of a newline at the end of the minified js file.