### PR TITLE
Make `this.ajax` overridable via the `opts.ajax` propery

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ https://raw.githubusercontent.com/stacktracejs/stacktrace-gps/master/dist/stackt
 options: Object
 * **sourceCache: Object (String URL => String Source)** - Pre-populate source cache to avoid network requests
 * **offline: Boolean (default false)** - Set to `true` to prevent all network requests
+* **ajax: Function (String URL => Promise(responseText))** - Function to be used for making X-Domain requests
  
 #### `.pinpoint(stackframe)` => Promise(StackFrame)
 Enhance function name and use source maps to produce a better StackFrame.

--- a/spec/stacktrace-gps-spec.js
+++ b/spec/stacktrace-gps-spec.js
@@ -26,6 +26,23 @@ describe('StackTraceGPS', function () {
         server.restore();
     });
 
+    describe('#Constructor', function () {
+        it('allows for overriding the "ajax" function via the "ajax" option property', function () {
+            runs(function() {
+                function ajax () {
+                    return Promise.resolve('');
+                }
+                var stackTraceGPS = new StackTraceGPS({ajax: ajax});
+                stackTraceGPS._get('http://localhost:9999/test.min.js').then(callback, errback);
+            });
+            waits(100);
+            runs(function() {
+                expect(callback).toHaveBeenCalled();
+                expect(errback).not.toHaveBeenCalled();
+            });
+        });
+    });
+
     describe('#_get', function () {
         it('avoids multiple in-flight network requests', function () {
             runs(function() {

--- a/spec/stacktrace-gps-spec.js
+++ b/spec/stacktrace-gps-spec.js
@@ -27,7 +27,7 @@ describe('StackTraceGPS', function () {
     });
 
     describe('#Constructor', function () {
-        it('allows for overriding the "ajax" function via the "ajax" option property', function () {
+        it('allows for overriding the "ajax" function via the "ajax" option', function () {
             runs(function() {
                 function ajax () {
                     return Promise.resolve('');

--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -125,6 +125,7 @@
      *      opts.sourceCache = {url: "Source String"} => preload source cache
      *      opts.offline = True to prevent network requests.
      *              Best effort without sources or source maps.
+     *      opts.ajax = Promise returning function to make X-Domain requests
      */
     return function StackTraceGPS(opts) {
         if (!(this instanceof StackTraceGPS)) {
@@ -134,7 +135,7 @@
 
         this.sourceCache = opts.sourceCache || {};
 
-        this.ajax = _xdr;
+        this.ajax = opts.ajax || _xdr;
 
         this._get = function _get(location) {
             return new Promise(function (resolve, reject) {


### PR DESCRIPTION
This is useful when stacktrace-gps.js is run in a Node context.
In particular, it allows for using this module without having to
"pollute" Node's global namespace with a `XMLHttpRequest` polyfill.