### PR TITLE
Tolerate charset definition in inline sourcemap

### DIFF
--- a/spec/stacktrace-gps-spec.js
+++ b/spec/stacktrace-gps-spec.js
@@ -438,5 +438,33 @@ describe('StackTraceGPS', function () {
                 expect(errback).not.toHaveBeenCalled();
             });
         });
+
+        it('tolerates inline source maps with parameters set', function() {
+            runs(function() {
+                var sourceMin = 'var foo=function(){};function bar(){}var baz=eval("XXX");//# sourceMappingURL=data:application/json;charset=utf8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInRlc3QuanMiXSwibmFtZXMiOlsiZm9vIiwiYmFyIiwiYmF6IiwiZXZhbCJdLCJtYXBwaW5ncyI6IkFBQUEsR0FBSUEsS0FBTSxZQUdWLFNBQVNDLFFBRVQsR0FBSUMsS0FBTUMsS0FBTSJ9';
+                server.respondWith('GET', 'test.min.js', [200, { 'Content-Type': 'application/x-javascript' }, sourceMin]);
+
+                var stackframe = new StackFrame(undefined, [], 'test.min.js', 1, 47);
+                new StackTraceGPS().pinpoint(stackframe).then(callback, errback)['catch'](debugErrback);
+            });
+            waits(100);
+            runs(function() {
+                server.respond();
+            });
+            waits(100);
+            runs(function() {
+                server.respond();
+            });
+            waits(100);
+            runs(function() {
+                server.respond();
+            });
+            waits(100);
+            runs(function() {
+                expect(callback).toHaveBeenCalledWith(new StackFrame('eval', [], 'test.js', 6, 10));
+                expect(errback).not.toHaveBeenCalled();
+            });
+
+        });
     });
 });

--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -146,15 +146,19 @@
                     reject(new Error('Cannot make network requests in offline mode'));
                 } else {
                     if (isDataUrl) {
-                        var supportedEncoding = 'application/json;base64';
-                        if (location.substr(5, supportedEncoding.length) !== supportedEncoding) {
-                            reject(new Error('The encoding of the inline sourcemap is not supported'));
-                        } else {
-                            var sourceMapStart = 'data:'.length + supportedEncoding.length + ','.length;
+                        // data URLs can have parameters.
+                        // see http://tools.ietf.org/html/rfc2397
+                        var supportedEncodingRegexp =
+                            /^data:application\/json;([\w=:"-]+;)*base64,/;
+                        var match = location.match(supportedEncodingRegexp);
+                        if (match) {
+                            var sourceMapStart = match[0].length;
                             var encodedSource = location.substr(sourceMapStart);
                             var source = window.atob(encodedSource);
                             this.sourceCache[location] = source;
                             resolve(source);
+                        } else {
+                            reject(new Error('The encoding of the inline sourcemap is not supported'));
                         }
                     } else {
                         var xhrPromise = this.ajax(location, {method: 'get'});


### PR DESCRIPTION
Per [RFC 2397](http://tools.ietf.org/html/rfc2397), data URLs can have parameters encoded in the format `foo=bar` (e.g. `charset=utf-8`). This PR modifies the data URL support check to support these URLs.