### PR TITLE
test for absolute urls before making urls absolute

### DIFF
--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -227,7 +227,7 @@
                     var sourceMappingURL = _findSourceMappingURL(source);
                     var isDataUrl = sourceMappingURL.substr(0, 5) === 'data:';
 
-                    if (sourceMappingURL[0] !== '/' && !isDataUrl) {
+                    if (sourceMappingURL[0] !== '/' && !isDataUrl && !(/^https?:\/\/|^\/\//i).test(sourceMappingURL)) {
                         sourceMappingURL = fileName.substring(0, fileName.lastIndexOf('/') + 1) + sourceMappingURL;
                     }
 


### PR DESCRIPTION
if you don't do this check then people with absolute source map urls (for use in chrome extensions for example) end up with mangled doubly absolute urls.