### PR TITLE
Fixing: https://github.com/stacktracejs/stacktrace-gps/issues/35

### DIFF
--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -283,7 +283,7 @@
                         sourceMappingURL = base + sourceMappingURL;
                     }
 
-                    this._get(sourceMappingURL).then(function(sourceMap) {
+                    return this._get(sourceMappingURL).then(function(sourceMap) {
                         if (typeof sourceMap === 'string') {
                             sourceMap = _parseJson(sourceMap.replace(/^\)\]\}'/, ''));
                         }
@@ -291,7 +291,7 @@
                             sourceMap.sourceRoot = base;
                         }
 
-                        _extractLocationInfoFromSourceMap(stackframe, sourceMap, sourceCache)
+                        return _extractLocationInfoFromSourceMap(stackframe, sourceMap, sourceCache)
                             .then(resolve)['catch'](function() {
                             resolve(stackframe);
                         });


### PR DESCRIPTION
## Description
When stacktrace.js is used with bluebird promise and if stacktrace is called with client side error to generate stack trace it throws following warning:
"Warning: a promise was created in a handler but was not returned from it"
This warning is coming from stacktrace-gps and it is happening because of https://github.com/petkaantonov/bluebird/blob/master/docs/docs/warning-explanations.md#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it. 
To fix this issue I have put return before promise to avoid a runway promise that is not connected to any promise chain.

## How Has This Been Tested?
I have tested it in my local application. After making fix it has stopped throwing these warnings. I have run gulp pr task to ensure linting and testing is passing after this  change.

## Checklist:
[X] Ran gulp pr 

