### PR TITLE
Parsing caching

### DIFF
--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -283,7 +283,7 @@
                         sourceMappingURL = base + sourceMappingURL;
                     }
 
-                    this._get(sourceMappingURL).then(function(sourceMap) {
+                    return this._get(sourceMappingURL).then(function(sourceMap) {
                         if (typeof sourceMap === 'string') {
                             sourceMap = _parseJson(sourceMap.replace(/^\)\]\}'/, ''));
                         }
@@ -291,7 +291,7 @@
                             sourceMap.sourceRoot = base;
                         }
 
-                        _extractLocationInfoFromSourceMap(stackframe, sourceMap, sourceCache)
+                        return _extractLocationInfoFromSourceMap(stackframe, sourceMap, sourceCache)
                             .then(resolve)['catch'](function() {
                             resolve(stackframe);
                         });


### PR DESCRIPTION

## Description
I have also faced issue similar to https://github.com/stacktracejs/stacktrace-gps/issues/41.
I have found that when stack trace is coming from single huge js file it becomes very costly to generate source map stack trace as it seems currently stacktrace-gps is doing costly processing multiple time, to avoid that I have made changes to caching parsing results and re use them if required.

## How Has This Been Tested?
Tested in my application and have seen almost 80% performance improvement while generating source map stack trace of error.

## Checklist:
- [X] gulp pr passes without errors
- [X] npm test` passes without errors
