### PR TITLE
Update stacktrace to 1.0.2 and switch to the new API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@ stacktrace-gps - Turn partial code location into precise code location
 ===================
 [![Build Status](https://travis-ci.org/stacktracejs/stacktrace-gps.svg?branch=master)](https://travis-ci.org/stacktracejs/stacktrace-gps) [![Coverage Status](https://img.shields.io/coveralls/stacktracejs/stacktrace-gps.svg)](https://coveralls.io/r/stacktracejs/stacktrace-gps) [![GitHub license](https://img.shields.io/github/license/stacktracejs/stacktrace-gps.svg)](http://unlicense.org)
 
-This library accepts a code location (in the form of a [StackFrame](https://github.com/stacktracejs/stackframe)) and 
+This library accepts a code location (in the form of a [StackFrame](https://github.com/stacktracejs/stackframe)) and
 returns a new StackFrame with a more accurate location (using [source maps](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/)) and guessed function names.
 
 ## Usage
 ```js
-var stackframe = new StackFrame(undefined, [], 'http://localhost:3000/file.min.js', 1, 3284);
+var stackframe = new StackFrame({fileName: 'http://localhost:3000/file.min.js', lineNumber: 1, columnNumber: 3284});
 var callback = function myCallback(foundFunctionName) { console.log(foundFunctionName); };
 
 // Such meta. Wow
@@ -17,15 +17,15 @@ var gps = new StackTraceGPS();
 
 // Pinpoint actual function name and source-mapped location
 gps.pinpoint(stackframe).then(callback, errback);
-=> Promise(StackFrame('fun', [], 'file.js', 203, 9), Error)
+=> Promise(StackFrame({functionName: 'fun', fileName: 'file.js', lineNumber: 203, columnNumber: 9}), Error)
 
 // Better location/name information from source maps
 gps.getMappedLocation(stackframe).then(callback, errback);
-=> Promise(StackFrame(undefined, [], 'file.js', 203, 9), Error)
+=> Promise(StackFrame({fileName: 'file.js', lineNumber: 203, columnNumber: 9}), Error)
 
 // Get function name from location information
 gps.findFunctionName(stackframe).then(callback, errback);
-=> Promise(StackFrame('fun', [], 'http://localhost:3000/file.min.js', 1, 3284), Error)
+=> Promise(StackFrame({functionName: 'fun', fileName: 'http://localhost:3000/file.min.js', lineNumber: 1, columnNumber: 3284}), Error)
 ```
 
 ## Installation
@@ -43,16 +43,16 @@ options: Object
 * **offline: Boolean (default false)** - Set to `true` to prevent all network requests
 * **ajax: Function (String URL => Promise(responseText))** - Function to be used for making X-Domain requests
 * **atob: Function (String => String)** - Function to convert base64-encoded strings to their original representation
- 
+
 #### `.pinpoint(stackframe)` => Promise(StackFrame)
 Enhance function name and use source maps to produce a better StackFrame.
-* **stackframe** - [StackFrame](https://github.com/stacktracejs/stackframe) or like object 
+* **stackframe** - [StackFrame](https://github.com/stacktracejs/stackframe) or like object
 e.g. {fileName: 'path/to/file.js', lineNumber: 100, columnNumber: 5}
- 
+
 #### `.findFunctionName(stackframe)` => Promise(StackFrame)
 Enhance function name and use source maps to produce a better StackFrame.
 * **stackframe** - [StackFrame](https://github.com/stacktracejs/stackframe) or like object
- 
+
 #### `.getMappedLocation(stackframe)` => Promise(StackFrame)
 Enhance function name and use source maps to produce a better StackFrame.
 * **stackframe** - [StackFrame](https://github.com/stacktracejs/stackframe) or like object

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "source-map": "0.5.6",
-    "stackframe": "~0.3"
+    "stackframe": "~1.0.2"
   },
   "devDependencies": {
     "colors": "^1.1.2",

--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -148,12 +148,12 @@
                     sourceCache[loc.source] = mappedSource;
                 }
                 resolve(
-                    new StackFrame(
-                        loc.name || stackframe.functionName,
-                        stackframe.args,
-                        loc.source,
-                        loc.line,
-                        loc.column));
+                    new StackFrame({
+                        functionName: loc.name || stackframe.functionName,
+                        args: stackframe.args,
+                        fileName: loc.source,
+                        lineNumber: loc.line,
+                        columnNumber: loc.column}));
             } else {
                 reject(new Error('Could not get original source for given stackframe and source map'));
             }
@@ -249,11 +249,12 @@
                     var guessedFunctionName = _findFunctionName(source, lineNumber, columnNumber);
                     // Only replace functionName if we found something
                     if (guessedFunctionName) {
-                        resolve(new StackFrame(guessedFunctionName,
-                            stackframe.args,
-                            stackframe.fileName,
-                            lineNumber,
-                            columnNumber));
+                        resolve(new StackFrame({
+                            functionName: guessedFunctionName,
+                            args: stackframe.args,
+                            fileName: stackframe.fileName,
+                            lineNumber: lineNumber,
+                            columnNumber: columnNumber}));
                     } else {
                         resolve(stackframe);
                     }


### PR DESCRIPTION
## Description
Update to the newest version of the stacktrace module and adapt to the backwards incompatible changes.

## Motivation and Context
stacktrace-gps was stuck on an old pre-1.0.0 version of the stacktrace module. That caused some confusion for me as I had to use an old version of stacktrace in my app for things to work out.

## How Has This Been Tested?
It has been tested using the existing test suite, which I've also updated to use the new StackFrame API.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] `node_modules/.bin/jscs -c .jscsrc stacktrace-gps.js` passes without errors (NOTE: jscs is not listed as a devDependency, but if I install it, the code does pass)
- [x] `npm test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes

