### PR TITLE
Add support for parsing ES6 style functions

### DIFF
--- a/spec/stacktrace-gps-spec.js
+++ b/spec/stacktrace-gps-spec.js
@@ -90,6 +90,32 @@ describe('StackTraceGPS', function() {
             }
         });
 
+        it('resolves source for class method', function(done) {
+            var stackframe = new StackFrame(undefined, [], 'http://localhost:9999/file.js', 2, 0);
+            var sourceCache = {'http://localhost:9999/file.js': 'class Foo {\nbar () {\n}\n }\n'};
+            new StackTraceGPS({sourceCache: sourceCache})
+                .findFunctionName(stackframe)
+                .then(callback, done.fail);
+
+            function callback(stackframe) {
+                expect(stackframe).toEqual(new StackFrame('bar', [], 'http://localhost:9999/file.js', 2, 0));
+                done();
+            }
+        });
+
+        it('resolves source for fat arrow functions', function(done) {
+            var stackframe = new StackFrame(undefined, [], 'http://localhost:9999/file.js', 1, 4);
+            var sourceCache = {'http://localhost:9999/file.js': 'var meow = () => { }'};
+            new StackTraceGPS({sourceCache: sourceCache})
+                .findFunctionName(stackframe)
+                .then(callback, done.fail);
+
+            function callback(stackframe) {
+                expect(stackframe).toEqual(new StackFrame('meow', [], 'http://localhost:9999/file.js', 1, 4));
+                done();
+            }
+        });
+
         it('finds function name within function expression', function(done) {
             var source = 'var foo = function() {};\nfunction bar() {}\nvar baz = eval("XXX")';
             jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({responseText: source});

--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -69,13 +69,16 @@
           /function\s+([^(]*?)\s*\(([^)]*)\)/,
           // {name} = eval()
           /['"]?([$_A-Za-z][$_A-Za-z0-9]*)['"]?\s*[:=]\s*(?:eval|new Function)\b/,
-        ]
+          // fn_name() {
+          /\b(?!(?:if|for|switch|while|with|catch)\b)(\S+)\s*\(.*?\)\s*{/,
+          // {name} = () => {
+          /['"]?([$_A-Za-z][$_A-Za-z0-9]*)['"]?\s*[:=]\s*\(.*?\)\s*=>/
+        ];
         var lines = source.split('\n');
 
         // Walk backwards in the source lines until we find the line which matches one of the patterns above
         var code = '';
         var maxLines = Math.min(lineNumber, 20);
-        var m;
         for (var i = 0; i < maxLines; ++i) {
             // lineNo is 1-based, source[] is 0-based
             var line = lines[lineNumber - i - 1];
@@ -87,8 +90,8 @@
             if (line) {
                 code = line + code;
                 var len = syntaxes.length;
-                for (var i = 0; i < len; i++) {
-                  var m = syntaxes[i].exec(code);
+                for (var index = 0; index < len; index++) {
+                  var m = syntaxes[index].exec(code);
                   if (m && m[1]) {
                       return m[1];
                   }

--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -62,12 +62,14 @@
     }
 
     function _findFunctionName(source, lineNumber/*, columnNumber*/) {
-        // function {name}({args}) m[1]=name m[2]=args
-        var reFunctionDeclaration = /function\s+([^(]*?)\s*\(([^)]*)\)/;
-        // {name} = function ({args}) TODO args capture
-        var reFunctionExpression = /['"]?([$_A-Za-z][$_A-Za-z0-9]*)['"]?\s*[:=]\s*function\b/;
-        // {name} = eval()
-        var reFunctionEvaluation = /['"]?([$_A-Za-z][$_A-Za-z0-9]*)['"]?\s*[:=]\s*(?:eval|new Function)\b/;
+        var syntaxes = [
+          // {name} = function ({args}) TODO args capture
+          /['"]?([$_A-Za-z][$_A-Za-z0-9]*)['"]?\s*[:=]\s*function\b/,
+          // function {name}({args}) m[1]=name m[2]=args
+          /function\s+([^(]*?)\s*\(([^)]*)\)/,
+          // {name} = eval()
+          /['"]?([$_A-Za-z][$_A-Za-z0-9]*)['"]?\s*[:=]\s*(?:eval|new Function)\b/,
+        ]
         var lines = source.split('\n');
 
         // Walk backwards in the source lines until we find the line which matches one of the patterns above
@@ -84,17 +86,12 @@
 
             if (line) {
                 code = line + code;
-                m = reFunctionExpression.exec(code);
-                if (m && m[1]) {
-                    return m[1];
-                }
-                m = reFunctionDeclaration.exec(code);
-                if (m && m[1]) {
-                    return m[1];
-                }
-                m = reFunctionEvaluation.exec(code);
-                if (m && m[1]) {
-                    return m[1];
+                var len = syntaxes.length;
+                for (var i = 0; i < len; i++) {
+                  var m = syntaxes[i].exec(code);
+                  if (m && m[1]) {
+                      return m[1];
+                  }
                 }
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds support for parsing two more styles of defining functions in ES6. 
 
1. ES6 Classmethods such as `bar`:

```
class Foo () {
    bar () {
    }
}                  
```

2. ES6 fat arrow methods such as `foo`:

```
var foo = () => {

}
```


## Motivation and Context
ES6 is getting wide adoption we want to support it.

## How Has This Been Tested?
I've added unit-tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] `node_modules/.bin/jscs -c .jscsrc stacktrace-gps.js` passes without errors
- [x] `npm test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
