### PR TITLE
Filter out some common bad function matches

### DIFF
--- a/spec/stacktrace-gps-spec.js
+++ b/spec/stacktrace-gps-spec.js
@@ -114,6 +114,18 @@ describe('StackTraceGPS', function() {
             }
         });
 
+        it('ignores special case invalid function declaration', function(done) {
+            var source = 'true ? warning(ReactCurrentOwner.current == null, \'_renderNewRootComponent(): Render methods should be a pure function \' + \'of props and state; triggering nested component updates from \' + \'render is not allowed. If necessary, trigger nested updates in \' + \'componentDidUpdate. Check the render method of %s.\', ReactCurrentOwner.current && ReactCurrentOwner.current.getName() || \'ReactCompositeComponent\') : void 0;';
+            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({responseText: source});
+            var originalStackFrame = new StackFrame('@test@', [], 'http://localhost:9999/file.js', 1, 0);
+            new StackTraceGPS().findFunctionName(originalStackFrame).then(callback, done.fail);
+
+            function callback(stackframe) {
+                expect(stackframe).toEqual(originalStackFrame);
+                done();
+            }
+        });
+
         it('finds function name within function evaluation', function(done) {
             var source = 'var foo = function() {};\nfunction bar() {}\nvar baz = eval("XXX")';
             jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({responseText: source});

--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -63,7 +63,7 @@
 
     function _findFunctionName(source, lineNumber/*, columnNumber*/) {
         // function {name}({args}) m[1]=name m[2]=args
-        var reFunctionDeclaration = /function\s+([^(]*?)\s*\(([^)]*)\)/;
+        var reFunctionDeclaration = /function\s+([^('"`]*?)\s*\(([^)]*)\)/;
         // {name} = function ({args}) TODO args capture
         var reFunctionExpression = /['"]?([$_A-Za-z][$_A-Za-z0-9]*)['"]?\s*[:=]\s*function\b/;
         // {name} = eval()


### PR DESCRIPTION
Resolves #46.

I know matching identifiers is [very hard](http://stackoverflow.com/questions/1661197/what-characters-are-valid-for-javascript-variable-names/9337047#9337047), so I added some common chars that should be ignored (string literals).