### PR TITLE
Matching the last sourceMappingURL in the file.

### DIFF
--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -125,13 +125,18 @@
         return true;
     }
 
+    var _reSourceMapping = /\/\/[#@] ?sourceMappingURL=([^\s'"]+)\s*$/gm;
+
     function _findSourceMappingURL(source) {
-        var m = /\/\/[#@] ?sourceMappingURL=([^\s'"]+)\s*$/m.exec(source);
-        if (m && m[1]) {
-            return m[1];
-        } else {
-            throw new Error('sourceMappingURL not found');
+        var allMatches = source.match(_reSourceMapping);
+        if (allMatches) {
+            var lastSourceMappingReference = allMatches[allMatches.length - 1];
+            var m = _reSourceMapping.exec(lastSourceMappingReference);
+            if (m && m[1]) {
+                return m[1];
+            }
         }
+        throw new Error('sourceMappingURL not found');
     }
 
     function _extractLocationInfoFromSourceMapSource(stackframe, sourceMapConsumer, sourceCache) {


### PR DESCRIPTION
Currently `_findSourceMappingURL` returns the first `sourceMappingURL`
uri it finds, but we really want is the last match.

## Motivation and Context
I found because on one of my project's bundle in development there is one dependency that is (for some reason) including a `sourceMappingURL` comment and that uri is being incorrectly returned instead of the bundle's source map.

## How Has This Been Tested?
`gulp test`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] `node_modules/.bin/jscs -c .jscsrc stacktrace-gps.js` passes without errors
- [x] `npm test` passes without errors
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
