### PR TITLE
Prefer the last //# sourceMappingURL in a file instead of the first

### DIFF
--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -227,8 +227,8 @@
          * Creating SourceMapConsumers is expensive, so this wraps the creation of a
          * SourceMapConsumer in a per-instance cache.
          *
-         * @param sourceMappingURL = {String} URL to fetch source map from
-         * @param defaultSourceRoot = Default source root for source map if undefined
+         * @param {String} sourceMappingURL = URL to fetch source map from
+         * @param {String} defaultSourceRoot = Default source root for source map if undefined
          * @returns {Promise} that resolves a SourceMapConsumer
          */
         this._getSourceMapConsumer = function _getSourceMapConsumer(sourceMappingURL, defaultSourceRoot) {
@@ -326,12 +326,13 @@
                         sourceMappingURL = defaultSourceRoot + sourceMappingURL;
                     }
 
-                    return this._getSourceMapConsumer(sourceMappingURL, defaultSourceRoot).then(function(sourceMapConsumer) {
-                        return _extractLocationInfoFromSourceMapSource(stackframe, sourceMapConsumer, sourceCache)
-                            .then(resolve)['catch'](function() {
-                            resolve(stackframe);
+                    return this._getSourceMapConsumer(sourceMappingURL, defaultSourceRoot)
+                        .then(function(sourceMapConsumer) {
+                            return _extractLocationInfoFromSourceMapSource(stackframe, sourceMapConsumer, sourceCache)
+                                .then(resolve)['catch'](function() {
+                                resolve(stackframe);
+                            });
                         });
-                    });
                 }.bind(this), reject)['catch'](reject);
             }.bind(this));
         };

--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -126,9 +126,14 @@
     }
 
     function _findSourceMappingURL(source) {
-        var m = /\/\/[#@] ?sourceMappingURL=([^\s'"]+)\s*$/m.exec(source);
-        if (m && m[1]) {
-            return m[1];
+        var sourceMappingUrlRegExp = /\/\/[#@] ?sourceMappingURL=([^\s'"]+)\s*$/mg;
+        var lastSourceMappingUrl;
+        var matchSourceMappingUrl;
+        while (matchSourceMappingUrl = sourceMappingUrlRegExp.exec(source)) {
+            lastSourceMappingUrl = matchSourceMappingUrl[1];
+        }
+        if (lastSourceMappingUrl) {
+            return lastSourceMappingUrl;
         } else {
             throw new Error('sourceMappingURL not found');
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

It seems like some Webpack setups (including mine) end up outputting several `//# sourceMappingURL=...` entries when both transpilation and bundling is in the picture.

In general it seems like the safest bet to go for the last one, as most tools tend to append the comment to the end of the file.
Thus the last one is most likely to pertain to the last operation that happened, be it transpilation, bundling, or uglification :)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

In my Webpack setup, stacktrace-gps tries to fetch a non-existent source map because my bundle contains multiple `//# sourceMappingURL=...` entries. This worked fine before https://github.com/stacktracejs/stacktrace-gps/issues/33 was merged, but now stacktrace-gps prefers the first `//# sourceMappingURL=...` when the file contains more than one.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

In my own application that uses Webpack and via a new unit test.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] `node_modules/.bin/jscs -c .jscsrc stacktrace-gps.js` passes without errors
- [x] `npm test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
