### PR TITLE
Catch errors when parsing JSON

### DIFF
--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -246,7 +246,7 @@
                             }
 
                             resolve(new SourceMap.SourceMapConsumer(sourceMapSource));
-                        }, reject);
+                        }).catch(reject);
                     }.bind(this));
                     this.sourceMapConsumerCache[sourceMappingURL] = sourceMapConsumerPromise;
                     resolve(sourceMapConsumerPromise);


### PR DESCRIPTION
Currently there's an unhandled promise reject in the Node process if the source map isn't valid JSON. This fixes it so that the promise rejection is forwarded instead.

## How Has This Been Tested?

Tried it by modifying node_modules on local.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] `node_modules/.bin/jscs -c .jscsrc stacktrace-gps.js` passes without errors
- [ ] `npm test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
