### PR TITLE
Parametric sourcemapurl for hidden sourcemaps. This change breaks nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-stacktrace-gps - Turn partial code location into precise code location
-===================
+# stacktrace-gps - Turn partial code location into precise code location
+
 [![Build Status](https://travis-ci.org/stacktracejs/stacktrace-gps.svg?branch=master)](https://travis-ci.org/stacktracejs/stacktrace-gps) [![Coverage Status](https://img.shields.io/coveralls/stacktracejs/stacktrace-gps.svg)](https://coveralls.io/r/stacktracejs/stacktrace-gps) [![GitHub license](https://img.shields.io/github/license/stacktracejs/stacktrace-gps.svg)](https://opensource.org/licenses/MIT)
 
 This library accepts a code location (in the form of a [StackFrame](https://github.com/stacktracejs/stackframe)) and
@@ -8,12 +8,21 @@ returns a new StackFrame with a more accurate location (using [source maps](http
 This is primarily a browser-centric library, but can be used with node.js. See the [Offline Usage section](#offline-usage) below.
 
 ## Usage
+
 ```js
-var stackframe = new StackFrame({fileName: 'http://localhost:3000/file.min.js', lineNumber: 1, columnNumber: 3284});
-var callback = function myCallback(foundFunctionName) { console.log(foundFunctionName); };
+var stackframe = new StackFrame({
+  fileName: "http://localhost:3000/file.min.js",
+  lineNumber: 1,
+  columnNumber: 3284
+});
+var callback = function myCallback(foundFunctionName) {
+  console.log(foundFunctionName);
+};
 
 // Such meta. Wow
-var errback = function myErrback(error) { console.log(StackTrace.fromError(error)); };
+var errback = function myErrback(error) {
+  console.log(StackTrace.fromError(error));
+};
 
 var gps = new StackTraceGPS();
 
@@ -31,25 +40,71 @@ gps.findFunctionName(stackframe).then(callback, errback);
 ```
 
 ### Offline Usage
+
 With a bit of preparation, you can use this library offline in any environment. Any encountered fileNames not in the cache return resolved
 Promises with the original StackFrame. StackTraceGPS will make a best effort to provide as good of response with what is given and will
 fallback to the original StackFrame if nothing better could be found.
 
 ```js
-var stack = ErrorStackParser.parse(new Error('boom'));
-console.assert(stack[0] == new StackFrame({fileName: 'http://localhost:9999/file.min.js', lineNumber: 1, columnNumber: 32}));
+var stack = ErrorStackParser.parse(new Error("boom"));
+console.assert(
+  stack[0] ==
+    new StackFrame({
+      fileName: "http://localhost:9999/file.min.js",
+      lineNumber: 1,
+      columnNumber: 32
+    })
+);
 
-var sourceCache = {'http://localhost:9999/file.min.js': 'var foo=function(){};function bar(){}var baz=eval("XXX");\n//# sourceMappingURL=file.js.map'};
-var sourceMap = '{"version":3,"sources":["./file.js"],"sourceRoot":"http://localhost:4000/","names":["foo","bar","baz","eval"],"mappings":"AAAA,GAAIA,KAAM,YACV,SAASC,QACT,GAAIC,KAAMC,KAAK","file":"file.min.js"}';
-var sourceMapConsumerCache = {'http://localhost:4000/file.js.map': new SourceMap.SourceMapConsumer(sourceMap)};
+var sourceCache = {
+  "http://localhost:9999/file.min.js":
+    'var foo=function(){};function bar(){}var baz=eval("XXX");\n//# sourceMappingURL=file.js.map'
+};
+var sourceMap =
+  '{"version":3,"sources":["./file.js"],"sourceRoot":"http://localhost:4000/","names":["foo","bar","baz","eval"],"mappings":"AAAA,GAAIA,KAAM,YACV,SAASC,QACT,GAAIC,KAAMC,KAAK","file":"file.min.js"}';
+var sourceMapConsumerCache = {
+  "http://localhost:4000/file.js.map": new SourceMap.SourceMapConsumer(
+    sourceMap
+  )
+};
 
-var gps = new StackTraceGPS({offline: true, sourceCache: sourceCache, sourceMapConsumerCache: sourceMapConsumerCache});
+var gps = new StackTraceGPS({
+  offline: true,
+  sourceCache: sourceCache,
+  sourceMapConsumerCache: sourceMapConsumerCache
+});
 gps.pinpoint(stack[0]).then(function(betterStackFrame) {
-    console.assert(betterStackFrame === new StackFrame({functionName: 'bar', fileName: 'http://localhost:9999/file.js', lineNumber: 2, columnNumber: 9}));
+  console.assert(
+    betterStackFrame ===
+      new StackFrame({
+        functionName: "bar",
+        fileName: "http://localhost:9999/file.js",
+        lineNumber: 2,
+        columnNumber: 9
+      })
+  );
+});
+```
+
+### Usage with hidden sourcemaps
+
+```js
+var sourcemapRoot = "http://localhost:4000/sourcemaps/";
+gps.pinpoint(stack[0], sourcemapRoot).then(function(betterStackFrame) {
+  console.assert(
+    betterStackFrame ===
+      new StackFrame({
+        functionName: "bar",
+        fileName: "http://localhost:9999/file.js",
+        lineNumber: 2,
+        columnNumber: 9
+      })
+  );
 });
 ```
 
 ## Installation
+
 ```
 npm install stacktrace-gps
 bower install stacktrace-gps
@@ -59,31 +114,41 @@ https://raw.githubusercontent.com/stacktracejs/stacktrace-gps/master/dist/stackt
 ## API
 
 #### `new StackTraceGPS(/*optional*/ options)` => StackTraceGPS
+
 options: Object
-* **sourceCache: Object (String URL : String Source)** - Pre-populate source cache to avoid network requests
-* **sourceMapConsumerCache: Object (Source Mapping URL : SourceMap.SourceMapConsumer)** - Pre-populate source cache to avoid network requests
-* **offline: Boolean (default false)** - Set to `true` to prevent all network requests
-* **ajax: Function (String URL => Promise(responseText))** - Function to be used for making X-Domain requests
-* **atob: Function (String => String)** - Function to convert base64-encoded strings to their original representation
+
+- **sourceCache: Object (String URL : String Source)** - Pre-populate source cache to avoid network requests
+- **sourceMapConsumerCache: Object (Source Mapping URL : SourceMap.SourceMapConsumer)** - Pre-populate source cache to avoid network requests
+- **offline: Boolean (default false)** - Set to `true` to prevent all network requests
+- **ajax: Function (String URL => Promise(responseText))** - Function to be used for making X-Domain requests
+- **atob: Function (String => String)** - Function to convert base64-encoded strings to their original representation
 
 #### `.pinpoint(stackframe)` => Promise(StackFrame)
+
 Enhance function name and use source maps to produce a better StackFrame.
-* **stackframe** - [StackFrame](https://github.com/stacktracejs/stackframe) or like object
-e.g. {fileName: 'path/to/file.js', lineNumber: 100, columnNumber: 5}
+
+- **stackframe** - [StackFrame](https://github.com/stacktracejs/stackframe) or like object
+  e.g. {fileName: 'path/to/file.js', lineNumber: 100, columnNumber: 5}
 
 #### `.findFunctionName(stackframe)` => Promise(StackFrame)
+
 Enhance function name and use source maps to produce a better StackFrame.
-* **stackframe** - [StackFrame](https://github.com/stacktracejs/stackframe) or like object
+
+- **stackframe** - [StackFrame](https://github.com/stacktracejs/stackframe) or like object
 
 #### `.getMappedLocation(stackframe)` => Promise(StackFrame)
+
 Enhance function name and use source maps to produce a better StackFrame.
-* **stackframe** - [StackFrame](https://github.com/stacktracejs/stackframe) or like object
+
+- **stackframe** - [StackFrame](https://github.com/stacktracejs/stackframe) or like object
 
 ## Browser Support
+
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/stacktracejs.svg)](https://saucelabs.com/u/stacktracejs)
 
 Functions that rely on [Source Maps](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/)
 (`pinpoint` and `getMappedLocation`) require recent browsers.
 
 ## Contributing
-Want to be listed as a *Contributor*? Start with the [Contributing Guide](CONTRIBUTING.md)!
+
+Want to be listed as a _Contributor_? Start with the [Contributing Guide](CONTRIBUTING.md)!

--- a/spec/stacktrace-gps-spec.js
+++ b/spec/stacktrace-gps-spec.js
@@ -1,30 +1,34 @@
 // jscs:disable maximumLineLength
-describe('StackTraceGPS', function() {
-    beforeEach(function() {
+describe('StackTraceGPS', function () {
+    beforeEach(function () {
         if (typeof Promise === 'undefined') {
             ES6Promise.polyfill();
         }
         jasmine.Ajax.install();
     });
 
-    afterEach(function() {
+    afterEach(function () {
         jasmine.Ajax.uninstall();
     });
 
-    describe('#Constructor', function() {
-        it('allows for overriding the "ajax" function via the "ajax" option', function(done) {
+    describe('#Constructor', function () {
+        it('allows for overriding the "ajax" function via the "ajax" option', function (done) {
             function ajax() {
                 return Promise.resolve('');
             }
 
-            var stackTraceGPS = new StackTraceGPS({ajax: ajax});
+            var stackTraceGPS = new StackTraceGPS({
+                ajax: ajax
+            });
             stackTraceGPS._get('http://localhost:9999/test.min.js').then(done, done.fail);
         });
     });
 
-    describe('#_get', function() {
-        it('avoids multiple in-flight network requests', function(done) {
-            jasmine.Ajax.stubRequest('http://localhost:9999/test.min.js').andReturn({responseText: 'OK'});
+    describe('#_get', function () {
+        it('avoids multiple in-flight network requests', function (done) {
+            jasmine.Ajax.stubRequest('http://localhost:9999/test.min.js').andReturn({
+                responseText: 'OK'
+            });
 
             var stackTraceGPS = new StackTraceGPS();
             stackTraceGPS._get('http://localhost:9999/test.min.js').then(callback, done.fail);
@@ -42,17 +46,20 @@ describe('StackTraceGPS', function() {
         });
     });
 
-    describe('#_getSourceMapConsumer', function() {
-        it('avoids duplicate SourceMapConsumers', function(done) {
+    describe('#_getSourceMapConsumer', function () {
+        it('avoids duplicate SourceMapConsumers', function (done) {
             var sourceMap = '{"version":3,"sources":["./test.js"],"names":["foo","bar","baz","eval"],"mappings":"AAAA,GAAIA,KAAM,YACV,SAASC,QACT,GAAIC,KAAMC,KAAK","file":"test.min.js"}';
             var sourceMapUrl = 'http://localhost:9999/test.js.map';
-            jasmine.Ajax.stubRequest(sourceMapUrl).andReturn({responseText: sourceMap});
+            jasmine.Ajax.stubRequest(sourceMapUrl).andReturn({
+                responseText: sourceMap
+            });
 
             var stackTraceGPS = new StackTraceGPS();
             stackTraceGPS._getSourceMapConsumer(sourceMapUrl).then(callback, done.fail);
             stackTraceGPS._getSourceMapConsumer(sourceMapUrl).then(callback, done.fail);
 
             var callCount = 0;
+
             function callback() {
                 callCount++;
                 if (callCount === 1) {
@@ -65,29 +72,44 @@ describe('StackTraceGPS', function() {
         });
     });
 
-    describe('#findFunctionName', function() {
-        it('rejects given non-object StackFrame', function(done) {
+    describe('#findFunctionName', function () {
+        it('rejects given non-object StackFrame', function (done) {
             StackTraceGPS().findFunctionName('').then(done.fail, done); // jshint ignore:line
         });
 
-        it('rejects given invalid URL String', function(done) {
+        it('rejects given invalid URL String', function (done) {
             new StackTraceGPS().findFunctionName(new StackFrame()).then(done.fail, done);
         });
 
-        it('rejects given invalid line number', function(done) {
-            var stackframe = new StackFrame({fileName: 'http://localhost:9999/file.js'});
+        it('rejects given invalid line number', function (done) {
+            var stackframe = new StackFrame({
+                fileName: 'http://localhost:9999/file.js'
+            });
             new StackTraceGPS().findFunctionName(stackframe).then(done.fail, done);
         });
 
-        it('rejects given invalid column number', function(done) {
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 10, columnNumber: -1});
+        it('rejects given invalid column number', function (done) {
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 10,
+                columnNumber: -1
+            });
             new StackTraceGPS().findFunctionName(stackframe).then(done.fail, done);
         });
 
-        it('rejects if source file could not be found', function(done) {
-            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({status: 404});
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 23, columnNumber: 0});
+        it('rejects if source file could not be found', function (done) {
+            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({
+                status: 404
+            });
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 23,
+                columnNumber: 0
+            });
             new StackTraceGPS().findFunctionName(stackframe).then(done.fail, errback);
+
             function errback(error) {
                 expect(error.message).toEqual('HTTP status: 404 retrieving http://localhost:9999/file.js');
                 done();
@@ -95,28 +117,59 @@ describe('StackTraceGPS', function() {
         });
 
         // Expected spy errback to have been called with [ { line : 123, column : 63, sourceURL : '/Users/ewendelin/src/stacktracejs/stacktrace-gps/spec/stacktrace-gps-spec.js' } ] but actual calls were [ { line : 9, column : 9351, sourceURL : '/Users/ewendelin/src/stacktracejs/stacktrace-gps/stacktrace-gps.js' } ]
-        it('rejects in offline mode if sources not in source cache', function(done) {
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 23, columnNumber: 0});
-            new StackTraceGPS({offline: true}).findFunctionName(stackframe).then(done.fail, done);
+        it('rejects in offline mode if sources not in source cache', function (done) {
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 23,
+                columnNumber: 0
+            });
+            new StackTraceGPS({
+                offline: true
+            }).findFunctionName(stackframe).then(done.fail, done);
         });
 
-        it('resolves sources from given sourceCache', function(done) {
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 1, columnNumber: 4});
-            var sourceCache = {'http://localhost:9999/file.js': 'var foo = function() {};\nfunction bar() {}\nvar baz = eval("XXX")'};
-            new StackTraceGPS({sourceCache: sourceCache})
+        it('resolves sources from given sourceCache', function (done) {
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 1,
+                columnNumber: 4
+            });
+            var sourceCache = {
+                'http://localhost:9999/file.js': 'var foo = function() {};\nfunction bar() {}\nvar baz = eval("XXX")'
+            };
+            new StackTraceGPS({
+                    sourceCache: sourceCache
+                })
                 .findFunctionName(stackframe)
                 .then(callback, done.fail);
 
             function callback(stackframe) {
-                expect(stackframe).toEqual(new StackFrame({functionName: 'foo', args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 1, columnNumber: 4}));
+                expect(stackframe).toEqual(new StackFrame({
+                    functionName: 'foo',
+                    args: [],
+                    fileName: 'http://localhost:9999/file.js',
+                    lineNumber: 1,
+                    columnNumber: 4
+                }));
                 done();
             }
         });
 
-        it('resolves source for class method', function(done) {
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 2, columnNumber: 0});
-            var sourceCache = {'http://localhost:9999/file.js': 'class Foo {\nbar () {\n}\n }\n'};
-            new StackTraceGPS({sourceCache: sourceCache})
+        it('resolves source for class method', function (done) {
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 2,
+                columnNumber: 0
+            });
+            var sourceCache = {
+                'http://localhost:9999/file.js': 'class Foo {\nbar () {\n}\n }\n'
+            };
+            new StackTraceGPS({
+                    sourceCache: sourceCache
+                })
                 .findFunctionName(stackframe)
                 .then(callback, done.fail);
 
@@ -126,10 +179,19 @@ describe('StackTraceGPS', function() {
             }
         });
 
-        it('resolves source for fat arrow functions', function(done) {
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 1, columnNumber: 4});
-            var sourceCache = {'http://localhost:9999/file.js': 'var meow = () => { }'};
-            new StackTraceGPS({sourceCache: sourceCache})
+        it('resolves source for fat arrow functions', function (done) {
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 1,
+                columnNumber: 4
+            });
+            var sourceCache = {
+                'http://localhost:9999/file.js': 'var meow = () => { }'
+            };
+            new StackTraceGPS({
+                    sourceCache: sourceCache
+                })
                 .findFunctionName(stackframe)
                 .then(callback, done.fail);
 
@@ -139,10 +201,17 @@ describe('StackTraceGPS', function() {
             }
         });
 
-        it('finds function name within function expression', function(done) {
+        it('finds function name within function expression', function (done) {
             var source = 'var foo = function() {};\nfunction bar() {}\nvar baz = eval("XXX")';
-            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({responseText: source});
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 1, columnNumber: 4});
+            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({
+                responseText: source
+            });
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 1,
+                columnNumber: 4
+            });
             new StackTraceGPS().findFunctionName(stackframe).then(callback, done.fail);
 
             function callback(stackframe) {
@@ -151,10 +220,17 @@ describe('StackTraceGPS', function() {
             }
         });
 
-        it('finds function name within function declaration', function(done) {
+        it('finds function name within function declaration', function (done) {
             var source = 'var foo = function() {};\nfunction bar() {}\nvar baz = eval("XXX")';
-            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({responseText: source});
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 2, columnNumber: 0});
+            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({
+                responseText: source
+            });
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 2,
+                columnNumber: 0
+            });
             new StackTraceGPS().findFunctionName(stackframe).then(callback, done.fail);
 
             function callback(stackframe) {
@@ -163,10 +239,18 @@ describe('StackTraceGPS', function() {
             }
         });
 
-        it('ignores special case invalid function declaration', function(done) {
+        it('ignores special case invalid function declaration', function (done) {
             var source = 'true ? warning(ReactCurrentOwner.current == null, \'_renderNewRootComponent(): Render methods should be a pure function \' + \'of props and state; triggering nested component updates from \' + \'render is not allowed. If necessary, trigger nested updates in \' + \'componentDidUpdate. Check the render method of %s.\', ReactCurrentOwner.current && ReactCurrentOwner.current.getName() || \'ReactCompositeComponent\') : void 0;';
-            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({responseText: source});
-            var originalStackFrame = new StackFrame({functionName: '@test@', args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 1, columnNumber: 0});
+            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({
+                responseText: source
+            });
+            var originalStackFrame = new StackFrame({
+                functionName: '@test@',
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 1,
+                columnNumber: 0
+            });
             new StackTraceGPS().findFunctionName(originalStackFrame).then(callback, done.fail);
 
             function callback(stackframe) {
@@ -175,10 +259,17 @@ describe('StackTraceGPS', function() {
             }
         });
 
-        it('finds function name within function evaluation', function(done) {
+        it('finds function name within function evaluation', function (done) {
             var source = 'var foo = function() {};\nfunction bar() {}\nvar baz = eval("XXX")';
-            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({responseText: source});
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 3, columnNumber: 3});
+            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({
+                responseText: source
+            });
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 3,
+                columnNumber: 3
+            });
             new StackTraceGPS().findFunctionName(stackframe).then(callback, done.fail);
 
             function callback(stackframe) {
@@ -187,10 +278,19 @@ describe('StackTraceGPS', function() {
             }
         });
 
-        it('finds function name within static functions', function(done) {
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 2, columnNumber: 8});
-            var sourceCache = {'http://localhost:9999/file.js': 'class Foo {\nstatic woof() {\n}\n}'};
-            new StackTraceGPS({sourceCache: sourceCache}).findFunctionName(stackframe).then(callback, done.fail);
+        it('finds function name within static functions', function (done) {
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 2,
+                columnNumber: 8
+            });
+            var sourceCache = {
+                'http://localhost:9999/file.js': 'class Foo {\nstatic woof() {\n}\n}'
+            };
+            new StackTraceGPS({
+                sourceCache: sourceCache
+            }).findFunctionName(stackframe).then(callback, done.fail);
 
             function callback(stackframe) {
                 expect(stackframe.functionName).toEqual('woof');
@@ -198,32 +298,65 @@ describe('StackTraceGPS', function() {
             }
         });
 
-        it('ignores commented out function definitions', function(done) {
+        it('ignores commented out function definitions', function (done) {
             var source = 'var foo = function() {};\n//function bar() {}\nvar baz = eval("XXX")';
-            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({responseText: source});
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 2, columnNumber: 0});
+            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({
+                responseText: source
+            });
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 2,
+                columnNumber: 0
+            });
             new StackTraceGPS().findFunctionName(stackframe).then(callback, done.fail);
 
             function callback(stackframe) {
-                expect(stackframe).toEqual(new StackFrame({functionName: 'foo', args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 2, columnNumber: 0}));
+                expect(stackframe).toEqual(new StackFrame({
+                    functionName: 'foo',
+                    args: [],
+                    fileName: 'http://localhost:9999/file.js',
+                    lineNumber: 2,
+                    columnNumber: 0
+                }));
                 done();
             }
         });
 
-        it('resolves to undefined if function name could not be found', function(done) {
-            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({status: 200});
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 1, columnNumber: 0});
+        it('resolves to undefined if function name could not be found', function (done) {
+            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({
+                status: 200
+            });
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 1,
+                columnNumber: 0
+            });
             new StackTraceGPS().findFunctionName(stackframe).then(callback, done.fail);
 
             function callback(stackframe) {
-                expect(stackframe).toEqual(new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 1, columnNumber: 0}));
+                expect(stackframe).toEqual(new StackFrame({
+                    args: [],
+                    fileName: 'http://localhost:9999/file.js',
+                    lineNumber: 1,
+                    columnNumber: 0
+                }));
                 done();
             }
         });
 
-        it('does not replace non-anonymous function name with anonymous', function(done) {
-            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({status: 200});
-            var originalStackFrame = new StackFrame({functionName: 'foo', args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 1, columnNumber: 0});
+        it('does not replace non-anonymous function name with anonymous', function (done) {
+            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({
+                status: 200
+            });
+            var originalStackFrame = new StackFrame({
+                functionName: 'foo',
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 1,
+                columnNumber: 0
+            });
             new StackTraceGPS().findFunctionName(originalStackFrame).then(callback, done.fail);
 
             function callback(stackframe) {
@@ -232,15 +365,27 @@ describe('StackTraceGPS', function() {
             }
         });
 
-        it('caches subsequent requests to the same location', function(done) {
+        it('caches subsequent requests to the same location', function (done) {
             var unit = new StackTraceGPS();
             var source = 'var foo = function() {};\nfunction bar() {}\nvar baz = eval("XXX")';
-            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({responseText: source});
+            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({
+                responseText: source
+            });
 
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 3, columnNumber: 3});
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 3,
+                columnNumber: 3
+            });
             unit.findFunctionName(stackframe).then(callback, done.fail);
 
-            var stackframe2 = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 2, columnNumber: 0});
+            var stackframe2 = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/file.js',
+                lineNumber: 2,
+                columnNumber: 0
+            });
             unit.findFunctionName(stackframe2).then(callback, done.fail);
 
             var callCount = 0;
@@ -254,47 +399,84 @@ describe('StackTraceGPS', function() {
         });
     });
 
-    describe('#getMappedLocation', function() {
-        it('rejects given invalid StackFrame', function(done) {
-            new StackTraceGPS().getMappedLocation('BOGUS').then(done.fail, done);
+    describe('#getMappedLocation', function () {
+        var defaultSourceRootParam = 'http://localhost:9999/'
+        it('rejects given invalid StackFrame', function (done) {
+            new StackTraceGPS().getMappedLocation('BOGUS', defaultSourceRootParam).then(done.fail, done);
         });
 
-        it('rejects if sourceMapURL not found', function(done) {
+        it('rejects if sourceMapURL not found', function (done) {
             var source = 'var foo=function(){};function bar(){}var baz=eval("XXX");';
-            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({responseText: source});
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 23, columnNumber: 0});
-            new StackTraceGPS().getMappedLocation(stackframe).then(done.fail, done);
-        });
-
-        it('rejects if source map file 404s', function(done) {
-            var source = 'var foo=function(){};function bar(){}var baz=eval("XXX");\n//# sourceMappingURL=test.js.map';
-            jasmine.Ajax.stubRequest('http://localhost:9999/test.js').andReturn({responseText: source});
-            jasmine.Ajax.stubRequest('http://localhost:9999/test.js.map').andReturn({status: 404});
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/test.js', lineNumber: 23, columnNumber: 0});
-            new StackTraceGPS().getMappedLocation(stackframe).then(done.fail, done);
-        });
-
-        describe('with inline sourcemaps', function() {
-            beforeEach(function() {
-                var sourceMin = 'var foo=function(){};function bar(){}var baz=eval("XXX");//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInRlc3QuanMiXSwibmFtZXMiOlsiZm9vIiwiYmFyIiwiYmF6IiwiZXZhbCJdLCJtYXBwaW5ncyI6IkFBQUEsR0FBSUEsS0FBTSxZQUdWLFNBQVNDLFFBRVQsR0FBSUMsS0FBTUMsS0FBTSJ9';
-                jasmine.Ajax.stubRequest('test.min.js').andReturn({responseText: sourceMin});
-                this.stackframe = new StackFrame({args: [], fileName: 'test.min.js', lineNumber: 1, columnNumber: 47});
+            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({
+                responseText: source
+            });
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: undefined,
+                lineNumber: 23,
+                columnNumber: 0
             });
 
-            it('supports inline source maps', function(done) {
-                new StackTraceGPS().getMappedLocation(this.stackframe).then(callback, done.fail);
+
+            new StackTraceGPS().getMappedLocation(stackframe, defaultSourceRootParam).then(done.fail, done);
+        });
+
+        it('rejects if source map file 404s', function (done) {
+            var source = 'var foo=function(){};function bar(){}var baz=eval("XXX");\n//# sourceMappingURL=test.js.map';
+            jasmine.Ajax.stubRequest('http://localhost:9999/test.js').andReturn({
+                responseText: source
+            });
+            jasmine.Ajax.stubRequest('http://localhost:9999/test.js.map').andReturn({
+                status: 404
+            });
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/test.js',
+                lineNumber: 23,
+                columnNumber: 0
+            });
+            new StackTraceGPS().getMappedLocation(stackframe).then(done.fail, done);
+        });
+
+        describe('with inline sourcemaps', function () {
+
+            beforeEach(function () {
+
+                var sourceMin = 'var foo=function(){};function bar(){}var baz=eval("XXX");//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInRlc3QuanMiXSwibmFtZXMiOlsiZm9vIiwiYmFyIiwiYmF6IiwiZXZhbCJdLCJtYXBwaW5ncyI6IkFBQUEsR0FBSUEsS0FBTSxZQUdWLFNBQVNDLFFBRVQsR0FBSUMsS0FBTUMsS0FBTSJ9';
+                jasmine.Ajax.stubRequest('test.min.js').andReturn({
+                    responseText: sourceMin
+                });
+                this.stackframe = new StackFrame({
+                    args: [],
+                    fileName: 'test.min.js',
+                    lineNumber: 1,
+                    columnNumber: 47
+                });
+            });
+
+            it('supports inline source maps', function (done) {
+                var defaultSourceRootParam = 'http://localhost:9999/'
+                new StackTraceGPS().getMappedLocation(this.stackframe, defaultSourceRootParam).then(callback, done.fail);
 
                 function callback(stackframe) {
-                    expect(stackframe).toEqual(new StackFrame({functionName: 'eval', args: [], fileName: 'test.js', lineNumber: 6, columnNumber: 10}));
+                    expect(stackframe).toEqual(new StackFrame({
+                        functionName: 'eval',
+                        args: [],
+                        fileName: 'http://localhost:9999/test.js',
+                        lineNumber: 6,
+                        columnNumber: 10
+                    }));
                     done();
                 }
             });
 
-            it('uses opts.atob if it was supplied in options', function(done) {
-                var atobSpy = jasmine.createSpy('atobSpy').and.callFake(function(str) {
+            it('uses opts.atob if it was supplied in options', function (done) {
+                var atobSpy = jasmine.createSpy('atobSpy').and.callFake(function (str) {
                     return window.atob(str);
                 });
-                new StackTraceGPS({atob: atobSpy}).getMappedLocation(this.stackframe).then(callback);
+                new StackTraceGPS({
+                    atob: atobSpy
+                }).getMappedLocation(this.stackframe).then(callback);
 
                 function callback() {
                     expect(atobSpy).toHaveBeenCalled();
@@ -302,7 +484,7 @@ describe('StackTraceGPS', function() {
                 }
             });
 
-            it('rejects if atob() does not exist', function(done) {
+            it('rejects if atob() does not exist', function (done) {
                 var oldAtob = window.atob;
                 window.atob = null;
                 new StackTraceGPS().getMappedLocation(this.stackframe).then(done.fail, errback)['catch'](errback);
@@ -315,73 +497,145 @@ describe('StackTraceGPS', function() {
             });
         });
 
-        it('tolerates inline source maps with parameters set', function(done) {
+        it('tolerates inline source maps with parameters set', function (done) {
             var sourceMin = 'var foo=function(){};function bar(){}var baz=eval("XXX");//# sourceMappingURL=data:application/json;charset=utf8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInRlc3QuanMiXSwibmFtZXMiOlsiZm9vIiwiYmFyIiwiYmF6IiwiZXZhbCJdLCJtYXBwaW5ncyI6IkFBQUEsR0FBSUEsS0FBTSxZQUdWLFNBQVNDLFFBRVQsR0FBSUMsS0FBTUMsS0FBTSJ9';
-            jasmine.Ajax.stubRequest('test.min.js').andReturn({responseText: sourceMin});
-            this.stackframe = new StackFrame({args: [], fileName: 'test.min.js', lineNumber: 1, columnNumber: 47});
+            jasmine.Ajax.stubRequest('test.min.js').andReturn({
+                responseText: sourceMin
+            });
+            this.stackframe = new StackFrame({
+                args: [],
+                fileName: 'test.min.js',
+                lineNumber: 1,
+                columnNumber: 47
+            });
+
             new StackTraceGPS().getMappedLocation(this.stackframe).then(callback, done.fail);
 
             function callback(stackframe) {
-                expect(stackframe).toEqual(new StackFrame({functionName: 'eval', args: [], fileName: 'test.js', lineNumber: 6, columnNumber: 10}));
+                expect(stackframe).toEqual(new StackFrame({
+                    functionName: 'eval',
+                    args: [],
+                    fileName: 'test.js',
+                    lineNumber: 6,
+                    columnNumber: 10
+                }));
                 done();
             }
         });
 
         it('ignores all but the last sourceMappingURL in the file', function (done) {
             var source = 'var foo=function(){};\n//# sourceMappingURL=ignoreme.js.map\nfunction bar(){}var baz=eval("XXX");\n//@ sourceMappingURL=test.js.map';
-            jasmine.Ajax.stubRequest('http://localhost:9999/test.min.js').andReturn({responseText: source});
+            jasmine.Ajax.stubRequest('http://localhost:9999/test.min.js').andReturn({
+                responseText: source
+            });
             var sourceMap = '{"version":3,"sources":["./test.js"],"names":["foo","bar","baz","eval"],"mappings":"AAAA,GAAIA,KAAM,YACV,SAASC,QACT,GAAIC,KAAMC,KAAK","file":"test.min.js"}';
-            jasmine.Ajax.stubRequest('http://localhost:9999/test.js.map').andReturn({responseText: sourceMap});
+            jasmine.Ajax.stubRequest('http://localhost:9999/test.js.map').andReturn({
+                responseText: sourceMap
+            });
 
-            var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/test.min.js', lineNumber: 1, columnNumber: 5});
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'http://localhost:9999/test.min.js',
+                lineNumber: 1,
+                columnNumber: 5
+            });
             new StackTraceGPS().getMappedLocation(stackframe).then(callback, done.fail);
 
             function callback(stackframe) {
-                expect(stackframe).toEqual(new StackFrame({functionName: 'foo', args: [], fileName: 'http://localhost:9999/test.js', lineNumber: 1, columnNumber: 4}));
+                expect(stackframe).toEqual(new StackFrame({
+                    functionName: 'foo',
+                    args: [],
+                    fileName: 'http://localhost:9999/test.js',
+                    lineNumber: 1,
+                    columnNumber: 4
+                }));
                 done();
             }
         });
 
-        describe('given source and source map that resolves', function() {
-            beforeEach(function() {
+        describe('given source and source map that resolves', function () {
+            beforeEach(function () {
                 var source = 'var foo=function(){};function bar(){}var baz=eval("XXX");\n//@ sourceMappingURL=test.js.map\n//# sourceURL=test.js';
-                jasmine.Ajax.stubRequest('http://localhost:9999/test.min.js').andReturn({responseText: source});
+                jasmine.Ajax.stubRequest('http://localhost:9999/test.min.js').andReturn({
+                    responseText: source
+                });
                 var sourceMap = '{"version":3,"sources":["./test.js"],"names":["foo","bar","baz","eval"],"mappings":"AAAA,GAAIA,KAAM,YACV,SAASC,QACT,GAAIC,KAAMC,KAAK","file":"test.min.js"}';
-                jasmine.Ajax.stubRequest('http://localhost:9999/test.js.map').andReturn({responseText: sourceMap});
+                jasmine.Ajax.stubRequest('http://localhost:9999/test.js.map').andReturn({
+                    responseText: sourceMap
+                });
             });
 
-            it('retrieves source mapped location for function expressions', function(done) {
-                var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/test.min.js', lineNumber: 1, columnNumber: 5});
+            it('retrieves source mapped location for function expressions', function (done) {
+                var stackframe = new StackFrame({
+                    args: [],
+                    fileName: 'http://localhost:9999/test.min.js',
+                    lineNumber: 1,
+                    columnNumber: 5
+                });
                 new StackTraceGPS().getMappedLocation(stackframe).then(callback, done.fail);
 
                 function callback(stackframe) {
-                    expect(stackframe).toEqual(new StackFrame({functionName: 'foo', args: [], fileName: 'http://localhost:9999/test.js', lineNumber: 1, columnNumber: 4}));
+                    expect(stackframe).toEqual(new StackFrame({
+                        functionName: 'foo',
+                        args: [],
+                        fileName: 'http://localhost:9999/test.js',
+                        lineNumber: 1,
+                        columnNumber: 4
+                    }));
                     done();
                 }
             });
 
-            it('retrieves source mapped location for function declarations', function(done) {
-                var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/test.min.js', lineNumber: 1, columnNumber: 32});
+            it('retrieves source mapped location for function declarations', function (done) {
+                var stackframe = new StackFrame({
+                    args: [],
+                    fileName: 'http://localhost:9999/test.min.js',
+                    lineNumber: 1,
+                    columnNumber: 32
+                });
                 new StackTraceGPS().getMappedLocation(stackframe).then(callback, done.fail);
 
                 function callback(stackframe) {
-                    expect(stackframe).toEqual(new StackFrame({functionName: 'bar', args: [], fileName: 'http://localhost:9999/test.js', lineNumber: 2, columnNumber: 9}));
+                    expect(stackframe).toEqual(new StackFrame({
+                        functionName: 'bar',
+                        args: [],
+                        fileName: 'http://localhost:9999/test.js',
+                        lineNumber: 2,
+                        columnNumber: 9
+                    }));
                     done();
                 }
             });
 
-            it('retrieves source mapped location for eval', function(done) {
-                var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/test.min.js', lineNumber: 1, columnNumber: 47});
+            it('retrieves source mapped location for eval', function (done) {
+                var stackframe = new StackFrame({
+                    args: [],
+                    fileName: 'http://localhost:9999/test.min.js',
+                    lineNumber: 1,
+                    columnNumber: 47
+                });
                 new StackTraceGPS().getMappedLocation(stackframe).then(callback, done.fail);
 
                 function callback(stackframe) {
-                    expect(stackframe).toEqual(new StackFrame({functionName: 'eval', args: [], fileName: 'http://localhost:9999/test.js', lineNumber: 3, columnNumber: 10}));
+                    expect(stackframe).toEqual(new StackFrame({
+                        functionName: 'eval',
+                        args: [],
+                        fileName: 'http://localhost:9999/test.js',
+                        lineNumber: 3,
+                        columnNumber: 10
+                    }));
                     done();
                 }
             });
 
-            it('does not replace non-empty functionName with empty value', function(done) {
-                var stackframe = new StackFrame({functionName: 'foo', args: [], fileName: 'http://localhost:9999/test.min.js', lineNumber: 2000, columnNumber: 4200});
+            it('does not replace non-empty functionName with empty value', function (done) {
+                var stackframe = new StackFrame({
+                    functionName: 'foo',
+                    args: [],
+                    fileName: 'http://localhost:9999/test.min.js',
+                    lineNumber: 2000,
+                    columnNumber: 4200
+                });
                 new StackTraceGPS().getMappedLocation(stackframe).then(callback, done.fail);
 
                 function callback(stackframe) {
@@ -391,53 +645,99 @@ describe('StackTraceGPS', function() {
             });
         });
 
-        describe('given cache entry for source map', function() {
-            it('resolves SourceMapConsumer from cache', function(done) {
-                var stackframe = new StackFrame({args: [], fileName: 'http://localhost:9999/file.min.js', lineNumber: 1, columnNumber: 4});
-                var sourceCache = {'http://localhost:9999/file.min.js': 'var foo=function(){};function bar(){}var baz=eval("XXX");\n//# sourceMappingURL=file.js.map'};
+        describe('given cache entry for source map', function () {
+            it('resolves SourceMapConsumer from cache', function (done) {
+                var stackframe = new StackFrame({
+                    args: [],
+                    fileName: 'http://localhost:9999/file.min.js',
+                    lineNumber: 1,
+                    columnNumber: 4
+                });
+                var sourceCache = {
+                    'http://localhost:9999/file.min.js': 'var foo=function(){};function bar(){}var baz=eval("XXX");\n//# sourceMappingURL=file.js.map'
+                };
                 var sourceMap = '{"version":3,"sources":["./file.js"],"sourceRoot":"http://localhost:9999/","names":["foo","bar","baz","eval"],"mappings":"AAAA,GAAIA,KAAM,YACV,SAASC,QACT,GAAIC,KAAMC,KAAK","file":"file.min.js"}';
-                var sourceMapConsumerCache = {'http://localhost:9999/file.js.map': new SourceMap.SourceMapConsumer(sourceMap)};
-                new StackTraceGPS({sourceCache: sourceCache, sourceMapConsumerCache: sourceMapConsumerCache})
+                var sourceMapConsumerCache = {
+                    'http://localhost:9999/file.js.map': new SourceMap.SourceMapConsumer(sourceMap)
+                };
+                new StackTraceGPS({
+                        sourceCache: sourceCache,
+                        sourceMapConsumerCache: sourceMapConsumerCache
+                    })
                     .getMappedLocation(stackframe)
                     .then(callback, done.fail);
 
                 function callback(stackframe) {
-                    expect(stackframe).toEqual(new StackFrame({functionName: 'foo', args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 1, columnNumber: 4}));
+                    expect(stackframe).toEqual(new StackFrame({
+                        functionName: 'foo',
+                        args: [],
+                        fileName: 'http://localhost:9999/file.js',
+                        lineNumber: 1,
+                        columnNumber: 4
+                    }));
                     done();
                 }
             });
         });
     });
 
-    describe('#pinpoint', function() {
-        beforeEach(function() {
+    describe('#pinpoint', function () {
+        beforeEach(function () {
             var sourceMin = 'var foo=function(){};function bar(){}var baz=eval("XXX");\n//@ sourceMappingURL=test.js.map';
-            jasmine.Ajax.stubRequest('test.min.js').andReturn({responseText: sourceMin});
+            jasmine.Ajax.stubRequest('test.min.js').andReturn({
+                responseText: sourceMin
+            });
             var sourceMap = '{"version":3,"sources":["./test.js"],"names":["foo","bar","baz","eval"],"mappings":"AAAA,GAAIA,KAAM,YACV,SAASC,QACT,GAAIC,KAAMC,KAAK","file":"test.min.js"}';
-            jasmine.Ajax.stubRequest('test.js.map').andReturn({responseText: sourceMap});
+            jasmine.Ajax.stubRequest('test.js.map').andReturn({
+                responseText: sourceMap
+            });
         });
 
-        it('combines findFunctionName and getMappedLocation', function(done) {
+        it('combines findFunctionName and getMappedLocation', function (done) {
             var source = 'var foo = function() {};\nfunction bar() {}\nvar baz = eval("XXX")';
-            jasmine.Ajax.stubRequest('test.js').andReturn({responseText: source});
+            jasmine.Ajax.stubRequest('test.js').andReturn({
+                responseText: source
+            });
 
-            var stackframe = new StackFrame({args: [], fileName: 'test.min.js', lineNumber: 1, columnNumber: 47});
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'test.min.js',
+                lineNumber: 1,
+                columnNumber: 47
+            });
             new StackTraceGPS().pinpoint(stackframe).then(callback, done.fail);
 
             function callback(stackframe) {
-                expect(stackframe).toEqual(new StackFrame({functionName: 'baz', args: [], fileName: 'test.js', lineNumber: 3, columnNumber: 10}));
+                expect(stackframe).toEqual(new StackFrame({
+                    functionName: 'baz',
+                    args: [],
+                    fileName: 'test.js',
+                    lineNumber: 3,
+                    columnNumber: 10
+                }));
                 done();
             }
         });
 
-        it('resolves with mapped location even if find function name fails', function(done) {
+        it('resolves with mapped location even if find function name fails', function (done) {
             jasmine.Ajax.stubRequest('test.js').andError();
 
-            var stackframe = new StackFrame({args: [], fileName: 'test.min.js', lineNumber: 1, columnNumber: 47});
+            var stackframe = new StackFrame({
+                args: [],
+                fileName: 'test.min.js',
+                lineNumber: 1,
+                columnNumber: 47
+            });
             new StackTraceGPS().pinpoint(stackframe).then(callback, done.fail);
 
             function callback(stackframe) {
-                expect(stackframe).toEqual(new StackFrame({functionName: 'eval', args: [], fileName: 'test.js', lineNumber: 3, columnNumber: 10}));
+                expect(stackframe).toEqual(new StackFrame({
+                    functionName: 'eval',
+                    args: [],
+                    fileName: 'test.js',
+                    lineNumber: 3,
+                    columnNumber: 10
+                }));
                 done();
             }
         });

--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -267,7 +267,7 @@
          * better StackFrame.
          *
          * @param {StackFrame} stackframe object
-         * @returns {Promise} that resolves with with source-mapped StackFrame
+         * @returns {Promise} that resolves with with source-mapped StackFrame 
          */
         this.pinpoint = function StackTraceGPS$$pinpoint(stackframe, defaultSourceRootParam) {
             return new Promise(function (resolve, reject) {


### PR DESCRIPTION
## Description
Parametric sourcemapurl for hidden sourcemaps.

## Motivation and Context
getMappedLocation functions accepts a parameter which provides soercemapurl.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] `node_modules/.bin/jscs -c .jscsrc stacktrace-gps.js` passes without errors
- [x] `npm test` passes without errors
- [ ] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
