### PR TITLE
getContext feature implementation (similar to TraceKit context field)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ https://raw.githubusercontent.com/stacktracejs/stacktrace-gps/master/dist/stackt
 options: Object
 * **sourceCache: Object (String URL : String Source)** - Pre-populate source cache to avoid network requests
 * **sourceMapConsumerCache: Object (Source Mapping URL : SourceMap.SourceMapConsumer)** - Pre-populate source cache to avoid network requests
+* **sourceCache: Object (String URL : String Source)** - Pre-populate source cache to avoid network requests
+* **sourceMapConsumerCache: Object (Source Mapping URL : SourceMap.SourceMapConsumer)** - Pre-populate source cache to avoid network requests
+* **offline: Boolean (default false)** - Set to `true` to prevent all network requests
+* **contextMaxLineLength: Number (default 200)** - The maximum length of one line in the context source code
+* **contextMaxLinesCount: Number (default 5)** - The maximum number of lines in the context source code 
 * **offline: Boolean (default false)** - Set to `true` to prevent all network requests
 * **ajax: Function (String URL => Promise(responseText))** - Function to be used for making X-Domain requests
 * **atob: Function (String => String)** - Function to convert base64-encoded strings to their original representation
@@ -77,6 +82,10 @@ Enhance function name and use source maps to produce a better StackFrame.
 
 #### `.getMappedLocation(stackframe)` => Promise(StackFrame)
 Enhance function name and use source maps to produce a better StackFrame.
+* **stackframe** - [StackFrame](https://github.com/stacktracejs/stackframe) or like object
+
+#### `.getContext(stackframe)` => Promise({ source, lineNumber, columnNumber })
+Returns the surrounding source code chunk (with the start position) for where the stackframe points.
 * **stackframe** - [StackFrame](https://github.com/stacktracejs/stackframe) or like object
 
 ## Browser Support

--- a/spec/stacktrace-gps-spec.js
+++ b/spec/stacktrace-gps-spec.js
@@ -442,4 +442,74 @@ describe('StackTraceGPS', function() {
             }
         });
     });
+
+    describe('#_getContextSingleLineIndexes', function() {
+        it('returns indexes that determine the correct range', function(done) {
+            test(1);
+            test(4);
+            test(5);
+            done();
+
+            function test(contextMaxLineLength) {
+                var stackTraceGPS = new StackTraceGPS({ contextMaxLineLength: contextMaxLineLength });
+                var line = '';
+                for (var length = 1; length <= 10; length++) {
+                    line += 'x';
+                    for (var columnNumber = 1; columnNumber <= 1; columnNumber++) {
+                        var indexes = stackTraceGPS._getContextSingleLineIndexes(line, columnNumber);
+                        expect(indexes[1] - indexes[0]).toBe(Math.min(contextMaxLineLength, length));
+                        expect(indexes[1] >= columnNumber && columnNumber > indexes[0]).toBe(true);
+                    }
+                }
+            }
+        });
+    });
+
+    describe('#_getContextMultipleLinesIndexes', function() {
+        it('returns indexes that determine the correct range', function(done) {
+            test(1);
+            test(4);
+            test(5);
+            done();
+
+            function test(contextMaxLinesCount) {
+                var stackTraceGPS = new StackTraceGPS({ contextMaxLinesCount: contextMaxLinesCount });
+                var lines = [];
+                for (var count = 1; count <= 10; count++) {
+                    lines.push('x');
+                    for (var columnNumber = 1; columnNumber <= 1; columnNumber++) {
+                        var indexes = stackTraceGPS._getContextMultipleLinesIndexes(lines, columnNumber);
+                        expect(indexes[1] - indexes[0]).toBe(Math.min(contextMaxLinesCount, count));
+                        expect(indexes[1] >= columnNumber && columnNumber > indexes[0]).toBe(true);
+                    }
+                }
+            }
+        });
+
+        it('avoids too long lines', function(done) {
+            var lines = [
+                'line',
+                'too long line',
+                'line',
+                'line',
+                'line',
+                'too long line',
+                'line'
+            ];
+            var stackTraceGPS = new StackTraceGPS({ contextMaxLineLength: 4, contextMaxLinesCount: 2 });
+            expect(stackTraceGPS._getContextMultipleLinesIndexes(lines, 1)).toEqual([0, 1]);
+            expect(stackTraceGPS._getContextMultipleLinesIndexes(lines, 3)).toEqual([2, 4]);
+            expect(stackTraceGPS._getContextMultipleLinesIndexes(lines, 4)).toEqual([2, 4]);
+            expect(stackTraceGPS._getContextMultipleLinesIndexes(lines, 5)).toEqual([3, 5]);
+            expect(stackTraceGPS._getContextMultipleLinesIndexes(lines, 7)).toEqual([6, 7]);
+            stackTraceGPS.contextMaxLinesCount = 5;
+            expect(stackTraceGPS._getContextMultipleLinesIndexes(lines, 1)).toEqual([0, 1]);
+            expect(stackTraceGPS._getContextMultipleLinesIndexes(lines, 3)).toEqual([2, 5]);
+            expect(stackTraceGPS._getContextMultipleLinesIndexes(lines, 4)).toEqual([2, 5]);
+            expect(stackTraceGPS._getContextMultipleLinesIndexes(lines, 5)).toEqual([2, 5]);
+            expect(stackTraceGPS._getContextMultipleLinesIndexes(lines, 7)).toEqual([6, 7]);
+            done();
+        });
+    });
+
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A new method `getContext` is implemented. The method gets the surrounding source code for where exception occurs. Similar to [TraceKit context](https://github.com/csnover/TraceKit/blob/master/tracekit.d.ts#L7), but much more clever and flexible.

I've seen 3 ways to implement this:
1. Create additional package.
2. Add the `context` field to the `stackframe` class.
3. Add the `getContext` method to the `stacktrace-gps`, which returns a separate object with the context source code.

I've decided to go the 3rd way, but if the stacktracejs team thinks, it should be done other way, just let me know.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's very standard feature for all the error tracking tools, to show the surrounding source code (badly named "context") where the error occurs. 
I've spent many hours fighting and hacking the TraceKit implementation (main problems: hard to configure the limits, very big and useless results for uglified code, inability to find out the line number of the code).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] `node_modules/.bin/jscs -c .jscsrc stacktrace-gps.js` passes without errors
- [x] `npm test` passes without errors
- [ ] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
