### PR TITLE
Fix findFunctionName regex sometimes matching if constructs

### DIFF
--- a/spec/stacktrace-gps-spec.js
+++ b/spec/stacktrace-gps-spec.js
@@ -198,6 +198,18 @@ describe('StackTraceGPS', function() {
             }
         });
 
+        it('ignores special case involving class functions', function(done) {
+            var source = 'if (a) { foo(); } else if (b) { bar(); }';
+            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({responseText: source});
+            var originalStackFrame = new StackFrame({functionName: '@test@', args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 1, columnNumber: 0});
+            new StackTraceGPS().findFunctionName(originalStackFrame).then(callback, done.fail);
+
+            function callback(stackframe) {
+                expect(stackframe).toEqual(originalStackFrame);
+                done();
+            }
+        });
+
         it('ignores commented out function definitions', function(done) {
             var source = 'var foo = function() {};\n//function bar() {}\nvar baz = eval("XXX")';
             jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({responseText: source});

--- a/spec/stacktrace-gps-spec.js
+++ b/spec/stacktrace-gps-spec.js
@@ -198,10 +198,22 @@ describe('StackTraceGPS', function() {
             }
         });
 
-        it('ignores special case involving class functions', function(done) {
+        it('ignores special case interpreting control structures as the function parameter list', function(done) {
             var source = 'if (a) { foo(); } else if (b) { bar(); }';
             jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({responseText: source});
             var originalStackFrame = new StackFrame({functionName: '@test@', args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 1, columnNumber: 0});
+            new StackTraceGPS().findFunctionName(originalStackFrame).then(callback, done.fail);
+
+            function callback(stackframe) {
+                expect(stackframe).toEqual(originalStackFrame);
+                done();
+            }
+        });
+
+        it('ignores special case interpreting control structures as the function name', function(done) {
+            var source = 'functionCall()\nif (condition) {';
+            jasmine.Ajax.stubRequest('http://localhost:9999/file.js').andReturn({responseText: source});
+            var originalStackFrame = new StackFrame({functionName: '@test@', args: [], fileName: 'http://localhost:9999/file.js', lineNumber: 2, columnNumber: 0});
             new StackTraceGPS().findFunctionName(originalStackFrame).then(callback, done.fail);
 
             function callback(stackframe) {

--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -71,7 +71,7 @@
             // {name} = eval()
             /['"]?([$_A-Za-z][$_A-Za-z0-9]*)['"]?\s*[:=]\s*(?:eval|new Function)\b/,
             // fn_name() {
-            /\b(?!(?:if|for|switch|while|with|catch)\b)(?:(?:static)\s+)?(\S+)\s*\(.*?\)\s*\{/,
+            /\b(?!(?:if|for|switch|while|with|catch)\b)(?:(?:static)\s+)?(\S+)\s*\([^)]*\)\s*\{/,
             // {name} = () => {
             /['"]?([$_A-Za-z][$_A-Za-z0-9]*)['"]?\s*[:=]\s*\(.*?\)\s*=>/
         ];

--- a/stacktrace-gps.js
+++ b/stacktrace-gps.js
@@ -71,7 +71,7 @@
             // {name} = eval()
             /['"]?([$_A-Za-z][$_A-Za-z0-9]*)['"]?\s*[:=]\s*(?:eval|new Function)\b/,
             // fn_name() {
-            /\b(?!(?:if|for|switch|while|with|catch)\b)(?:(?:static)\s+)?(\S+)\s*\([^)]*\)\s*\{/,
+            /\b(?!(?:if|for|switch|while|with|catch)\b)(?:(?:static)\s+)?([^('"`\s]+?)\s*\([^)]*\)\s*\{/,
             // {name} = () => {
             /['"]?([$_A-Za-z][$_A-Za-z0-9]*)['"]?\s*[:=]\s*\(.*?\)\s*=>/
         ];


### PR DESCRIPTION
Sometimes the `findFunctionName` function would falsely identify a snippet somewhere around an if/while/catch construct (basically anything that had a block with it)

## Description
The regex that matched with the snippet basically attempted to match anything on the form `<function name><whitespace>(<parameter list>)<whitespace>{`, so things like the following would match:
-  `foo(); } else if (b) {` (`); } else if (b`, in this case, would be the parameter list)
- `functionCall()\nif (condition) {` (in this case, `functionCall()\nif ` would be the function name)

To work around that, I changed the <function name> regex to not matching opening parenthesis, and the <parameter list> regex to not match any closing parenthesis.

## Motivation and Context
Fixes #54

## How Has This Been Tested?
I've added an unit test, and I've tested this change with some private code that also happened to trigger this bug

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] `npm run lint` passes without errors
- [x] `npm run test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
